### PR TITLE
Do not consider timestamps in messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: node_js
 sudo: false
 
 env: 
-- CODE_TESTS_PATH=$TRAVIS_BUILD_DIR/out/test/integrationtest CODE_TESTS_WORKSPACE=$TRAVIS_BUILD_DIR/test/integrationtest/testLogs CODE_VERSION=1.20.1
-  # Todo: Remove 'CODE_VERSION' attribute after the following issue is resolved.
-  # https://github.com/Microsoft/vscode/issues/47744
+- CODE_TESTS_PATH=$TRAVIS_BUILD_DIR/out/test/integrationtest CODE_TESTS_WORKSPACE=$TRAVIS_BUILD_DIR/test/integrationtest/testLogs
 
 stages:
   - build

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: node_js
 sudo: false
 
 env: 
-- CODE_TESTS_PATH=$TRAVIS_BUILD_DIR/out/test/integrationtest CODE_TESTS_WORKSPACE=$TRAVIS_BUILD_DIR/test/integrationtest/testLogs
+- CODE_TESTS_PATH=$TRAVIS_BUILD_DIR/out/test/integrationtest CODE_TESTS_WORKSPACE=$TRAVIS_BUILD_DIR/test/integrationtest/testLogs CODE_VERSION=1.20.1
+  # Todo: Remove 'CODE_VERSION' attribute after the following issue is resolved.
+  # https://github.com/Microsoft/vscode/issues/47744
 
 stages:
   - build

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 		"jasmine-core": "^2.9.1",
 		"tslint": "^5.9.1",
 		"typescript": "^2.6.2",
-		"vscode": "^1.1.10"
+		"vscode": "^1.1.14"
 	},
 	"dependencies": {
 		"moment": "^2.20.1"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 		"jasmine-core": "^2.9.1",
 		"tslint": "^5.9.1",
 		"typescript": "^2.6.2",
-		"vscode": "^1.1.14"
+		"vscode": "^1.1.10"
 	},
 	"dependencies": {
 		"moment": "^2.20.1"

--- a/src/TimePeriodCalculator.ts
+++ b/src/TimePeriodCalculator.ts
@@ -42,17 +42,20 @@ class TimePeriodCalculator {
         const selContent = data;
 
         // Clock times with optional timezone ("09:13:16", "09:13:16.323", "09:13:16+01:00")
-        const clockPattern = '\\d{2}:\\d{2}(?::\\d{2}(?:[.,]\\d{3,})?)?(?:Z| ?[+-]\\d{2}:\\d{2})?\\b';
+        let clockPattern = '\\d{2}:\\d{2}(?::\\d{2}(?:[.,]\\d{3,})?)?(?:Z| ?[+-]\\d{2}:\\d{2})?\\b';
 
         // ISO dates ("2016-08-23")
-        const isoDatePattern = '\\b\\d{4}-\\d{2}-\\d{2}(?:T|\\b)';
+        const isoDatePattern = '^\\d{4}-\\d{2}-\\d{2}(?:T|\\b)';
 
         // Culture specific dates ("23/08/2016", "23.08.2016")
-        const cultureDatesPattern = '\\b\\d{2}[^\\w\\s]\\d{2}[^\\w\\s]\\d{4}\\b';
+        const cultureDatesPattern = '^\\d{2}[^\\w\\s]\\d{2}[^\\w\\s]\\d{4}\\b';
 
         // Match '2016-08-23 09:13:16.323' as well as '29.01.2018 09:13:34,001'
         const dateTimePattern = '((?:' + isoDatePattern + '|' + cultureDatesPattern + '){1} ?' +
             '(?:' + clockPattern + '){1})';
+
+        // Only match at the beginning of a line.
+        clockPattern =  '^' + clockPattern;
 
         // Match 2017-09-29 as well as 29/01/2019
         const datesPattern = '(' + isoDatePattern + '|' + cultureDatesPattern + '){1}';
@@ -64,7 +67,7 @@ class TimePeriodCalculator {
 
         for (const item of rankedPattern) {
             matches = [];
-            const timeRegEx = new RegExp(item, 'g');
+            const timeRegEx = new RegExp(item, 'gm');
 
             let match = timeRegEx.exec(selContent);
 

--- a/test/integrationtest/testLogs/firstLog.log
+++ b/test/integrationtest/testLogs/firstLog.log
@@ -1,5 +1,5 @@
 2018-01-27 10:38:20.442 [8988] INFO  [Bootstrapper]: Hello World
-2018-01-27 10:38:20.443 [8988] INFO  [Bootstrapper]: Hello at 2018-01-27 10:38:20.447
+2018-01-27 10:38:20.443 [8988] INFO  [Bootstrapper]: Hello World
 2018-01-27 10:38:25.459 [8988] INFO  [Bootstrapper]: Hello World 
 2018-01-27 10:38:25.459 [8988] INFO  [Bootstrapper]: Hello World 
 27.01.2018 19:38:28,982 [8988] Verbose [Application]: Hello World

--- a/test/integrationtest/testLogs/firstLog.log
+++ b/test/integrationtest/testLogs/firstLog.log
@@ -1,5 +1,5 @@
 2018-01-27 10:38:20.442 [8988] INFO  [Bootstrapper]: Hello World
-2018-01-27 10:38:20.443 [8988] INFO  [Bootstrapper]: Hello World 
+2018-01-27 10:38:20.443 [8988] INFO  [Bootstrapper]: Hello at 2018-01-27 10:38:20.447
 2018-01-27 10:38:25.459 [8988] INFO  [Bootstrapper]: Hello World 
 2018-01-27 10:38:25.459 [8988] INFO  [Bootstrapper]: Hello World 
 27.01.2018 19:38:28,982 [8988] Verbose [Application]: Hello World

--- a/test/unittest/TimePeriodCalculator.test.ts
+++ b/test/unittest/TimePeriodCalculator.test.ts
@@ -13,9 +13,9 @@ describe('TimePeriodCalculator', () => {
 
         it('gets the correct timePeriod from "YYYY-MM-DD" and "DD.MM.YYYY".', () => {
             // Arrange
-            const logContent = '2018-01-27 [0234ß\n\b\r0?234%&\n} my first logging\n\
-                                28.01.2020 my second logging 0 $%34&/)(34=}?23\n\
-                                28.02.2020 my third logging 0 $%34&/)(34=}?23';
+            const logContent = '2018-01-27 [0234ß\n\r0?234%&\n\r} my first logging\
+                            \n\r28.01.2020 my second logging 0 $%34&/)(34=}?23\
+                            \n\r28.02.2020 my third logging 0 $%34&/)(34=}?23';
             const expected = moment.duration({ days: 1, months: 1, years: 2 });
 
             // Act
@@ -27,9 +27,9 @@ describe('TimePeriodCalculator', () => {
 
         it('gets the correct timePeriod from "hh:mm:ss.sss" and "hh:mm:ss.sss".', () => {
             // Arrange
-            const logContent = '10:38:28.935 [0234ß\n\b\r0?234%&\n} my first logging\n\
-                                12:50:29,901 my second logging 0 $%34&/)(34=}?23\n\
-                                16:51:29,001 my third logging 0 $%34&/)(34=}?23';
+            const logContent = '10:38:28.935 [0234ß\n\b\r0?234%&\n\r} my first logging\
+                            \n\r12:50:29,901 my second logging 0 $%34&/)(34=}?23\
+                            \n\r16:51:29,001 my third logging 0 $%34&/)(34=}?23';
             const expected = moment.duration({ seconds: 0.066, minutes: 13, hours: 6 });
 
             // Act
@@ -41,9 +41,9 @@ describe('TimePeriodCalculator', () => {
 
         it('gets the correct timePeriod from "YYYY-MM-DDThh:mm:ss.sssZ" and "DD/MM/YYYThh:mm:ss,sssZ".', () => {
             // Arrange
-            const logContent = '2018-01-27T10:38:28.935Z [0234ß\n\b\r0?234%&\n} my first logging\n\
-                                07.28.2019T16:51:29,001Z my second logging 0 $%34&/)(34=}?23\n\
-                                2020-02-28T16:51:29.001Z my third logging 0 $%34&/)(34=}?23';
+            const logContent = '2018-01-27T10:38:28.935Z [0234ß\n\b\r0?234%&\n\r} my first logging\
+                            \n\r07.28.2019T16:51:29,001Z my second logging 0 $%34&/)(34=}?23\
+                            \n\r2020-02-28T16:51:29.001Z my third logging 0 $%34&/)(34=}?23';
             const expected = moment.duration({ seconds: 0.066, minutes: 13, hours: 6, days: 1, months: 1, years: 2 });
 
             // Act
@@ -55,9 +55,9 @@ describe('TimePeriodCalculator', () => {
 
         it('gets the correct timePeriod from "YYYY-MM-DD hh:mm:ss.sss" and "DD/MM/YYY hh:mm:ss,sss".', () => {
             // Arrange
-            const logContent = '2018-01-27 10:38:28.935 [0234ß\n\b\r0?234%&\n} my first logging\n\
-                                07.28.2019 16:51:29,001 my second logging 0 $%34&/)(34=}?23\n\
-                                28/02/2020 16:51:29,001 my third logging 0 $%34&/)(34=}?23';
+            const logContent = '2018-01-27 10:38:28.935 [0234ß\n\b\r0?234%&\n\r} my first logging\
+                            \n\r07.28.2019 16:51:29,001 my second logging 0 $%34&/)(34=}?23\
+                            \n\r28/02/2020 16:51:29,001 my third logging 0 $%34&/)(34=}?23';
             const expected = moment.duration({ seconds: 0.066, minutes: 13, hours: 6, days: 1, months: 1, years: 2 });
 
             // Act
@@ -69,9 +69,9 @@ describe('TimePeriodCalculator', () => {
 
         it('gets the correct timePeriod from "YYYY-MM-DD hh:mm" and MM/DD/YYYY hh:mm".', () => {
             // Arrange
-            const logContent = '2018-01-27 10:38 [0234ß\n\b\r0?234%&\n} my first logging\n\
-                                07.28.2019 16:51:29,001 my second logging 0 $%34&/)(34=}?23\n\
-                                02/28/2020 16:51 my third logging 0 $%34&/)(34=}?23';
+            const logContent = '2018-01-27 10:38 [0234ß\n\b\r0?234%&\n\r} my first logging\
+                            \n\r07.28.2019 16:51:29,001 my second logging 0 $%34&/)(34=}?23\
+                            \n\r02/28/2020 16:51 my third logging 0 $%34&/)(34=}?23';
             const expected = moment.duration({ minutes: 13, hours: 6, days: 1, months: 1, years: 2 });
 
             // Act
@@ -83,9 +83,23 @@ describe('TimePeriodCalculator', () => {
 
         it('should only consider log statements with the same format (length).', () => {
             // Arrange
-            const logContent = '2018-01-27 [0234ß\n\b\r0?234%&\n} my first logging\n\
-                            07.28.2019 16:51:29,001 my second logging 0 $%34&/)(34=}?23\n\
-                            02/28/2020 my third logging 0 $%34&/)(34=}?23';
+            const logContent = '2018-01-27 [0234ß\n\b\r0?234%&\n\r} my first logging\
+                            \n\r07.28.2019 16:51:29,001 my second logging 0 $%34&/)(34=}?23\
+                            \n\r02/28/2020 my third logging 0 $%34&/)(34=}?23';
+            const expected = moment.duration({ days: 1, months: 1, years: 2 });
+
+            // Act
+            const result = testObject.getTimePeriod(logContent);
+
+            // Assert
+            expect(result.asMilliseconds()).toBe(expected.asMilliseconds());
+        });
+
+        it ('should only consider log statements on the very beginning of a line.', () => {
+            // Arrange
+            const logContent = '2018-01-27 [0234ß\n\b\r0?234%&\n\r} my first logging\
+                \n\r07.28.2019 16:51:29,001 my second logging 0 $%34&/)(34=}?23\
+                \n\r02/28/2020 my third logging 0 $%34&/)(34=}?23; 2021-03-29 my fourth statement on same line.';
             const expected = moment.duration({ days: 1, months: 1, years: 2 });
 
             // Act


### PR DESCRIPTION
@emilast this PR now is ready.
### Changes
* Now only timestamps at the very beginning of a line are considered for duration calculation
* Added a unittest
* Extended test log files of integrationtests

### Related Issues
Fixes #54 