### PR TITLE
Enable Background in custom pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+### Unreleased
+
+* New setting: **Background color for custom highlighting patterns**
+  * Now in addition it is possible to add a `background` color for custom patterns.
+
 ### 2.4.3 - 9 January 2019
 
 * Updated all dependencies to fix security vulnerabilities in `event-stream` and `flatmap-stream`.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ The patterns are defined in the user settings like in this example:
     },
     {
         "pattern": "E/\\w+",
-        "foreground": "#af1f1f"
+        "foreground": "#af1f1f",
+        "background": "blue"
     }
 ]
 ```
@@ -128,6 +129,8 @@ The patterns are defined in the user settings like in this example:
 * `pattern` - The matching expression. This can be either a string constant or a JavaScript regular expression (remember to **escape special characters**).
 
 * `foreground` - The color to use as foreground color for the matched pattern. Use hex colors or predefined VS Code colors.
+
+* `background` - [Optional] The color to use as background color for the matched pattern. Use hex colors or predefined VS Code colors.
 
 ![Custom Pattern Sample](content/CustomPattern-Sample.gif)  
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,12 @@
 								"type": "string",
 								"title": "The color.",
 								"description": "The foreground color that will be used for highlighting."
+							},
+							"background": {
+								"pattern": "^[^$|^\\s]",
+								"type": "string",
+								"title": "The color.",
+								"description": "The background color that will be used for highlighting."
 							}
 						},
 						"required": [

--- a/src/CustomPattern.ts
+++ b/src/CustomPattern.ts
@@ -5,14 +5,17 @@ import * as vscode from 'vscode';
 class CustomPattern {
     public readonly pattern: string;
     public readonly foreground: string;
+    public readonly background: string;
     public readonly regexes: RegExp[];
     public readonly decoration: vscode.TextEditorDecorationType;
 
-    public constructor(pattern: string, foreground: string) {
+    public constructor(pattern: string, foreground: string, background: string) {
         this.pattern = pattern;
         this.foreground = foreground;
+        this.background = background;
         this.regexes = this.createRegex(pattern);
         this.decoration = vscode.window.createTextEditorDecorationType({
+            backgroundColor: this.background,
             color: this.foreground,
             rangeBehavior: vscode.DecorationRangeBehavior.ClosedClosed
         });

--- a/src/CustomPatternDecorator.ts
+++ b/src/CustomPatternDecorator.ts
@@ -18,7 +18,7 @@ class CustomPatternDecorator {
 
     public updateConfiguration(): void {
         const configPatterns = vscode.workspace.getConfiguration('logFileHighlighter').get(
-            'customPatterns') as Array<{ pattern: string, foreground: string }>;
+            'customPatterns') as Array<{ pattern: string, foreground: string, background?: string }>;
 
         for (const pattern of this._configPattern) {
             pattern.dispose();
@@ -28,7 +28,7 @@ class CustomPatternDecorator {
 
         for (const item of configPatterns) {
             if (item.foreground !== undefined && item.pattern !== undefined) {
-                this._configPattern.push(new CustomPattern(item.pattern, item.foreground));
+                this._configPattern.push(new CustomPattern(item.pattern, item.foreground, item.background));
             }
         }
     }

--- a/test/integrationtest/CustomPatternDecorator.test.ts
+++ b/test/integrationtest/CustomPatternDecorator.test.ts
@@ -17,7 +17,8 @@ describe('CustomPatternDecorator', () => {
             },
             {
                 pattern: 'E/\\w+',
-                foreground: 'red'
+                foreground: 'red',
+                background: 'yellow'
             }
         ]).then(() => done());
 
@@ -79,7 +80,8 @@ describe('CustomPatternDecorator', () => {
                 },
                 {
                     pattern: 'E/\\w+',
-                    foreground: 'darkred'
+                    foreground: 'darkred',
+                    background: 'yellow'
                 }
             ]).then(() => {
                 expect(decoratorSpy.calls.count()).toBe(1);

--- a/test/integrationtest/TimePeriodController.test.ts
+++ b/test/integrationtest/TimePeriodController.test.ts
@@ -128,6 +128,7 @@ describe('TimePeriodController', () => {
                                             preview: false,
                                             selection: new Selection(new Position(0, 0), new Position(2, 0))
                                         });
+                                        done();
                                     },
                                     (reason) => {
                                         done.fail(reason);


### PR DESCRIPTION
Fixes #67: Enable background color in custom pattern
* Added setting
* Adjusted controller
* Updated readme and changelog

Idk why the integration tests fail on travis. However they pass when exectued locally