### PR TITLE
Prevent duration calculation for a single line selected.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+### 2.7.1 - Unreleased
+
+* Fixed a bug that caused the extension to crash on activation.
+
 ### 2.7.0 - 25 Dec 2019
 
 * Changed the **Visualization of Time Duration** feature. Now it does not anymore require timestamps to be at the very beginning of a line. Instead the first occurrence of a timestamp in a line is used.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "LogFileHighlighter",
-	"version": "2.7.0",
+	"version": "2.7.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"Other"
 	],
 	"license": "MIT",
-	"version": "2.7.0",
+	"version": "2.7.1",
 	"bugs": {
 		"url": "https://github.com/emilast/vscode-logfile-highlighter/issues"
 	},

--- a/src/TimePeriodController.ts
+++ b/src/TimePeriodController.ts
@@ -50,17 +50,26 @@ class TimePeriodController {
 
             this._statusBarItem.text = '';
 
-            // Get the selections first and last non empty line
-            const firstLine: vscode.TextLine = doc.lineAt(editor.selection.start.line);
-            let lastLine: vscode.TextLine;
-            // If last line is not partially selected use last but first line
-            if (editor.selection.end.character === 0) {
-                lastLine = doc.lineAt(editor.selection.end.line - 1);
-            } else {
-                lastLine = doc.lineAt(editor.selection.end.line);
-            }
+            const startLineNumber = editor.selection.start.line;
+            let endLineNumber = editor.selection.end.line;
+            let timePeriod = undefined;
 
-            const timePeriod = firstLine.text !== lastLine.text ? this._timeCalculator.getTimePeriod(firstLine.text, lastLine.text) : undefined;
+            if (startLineNumber !== endLineNumber) {
+
+                // Get the selections first and last non empty line
+                const startLine: vscode.TextLine = doc.lineAt(startLineNumber);
+                let endLine: vscode.TextLine;
+
+                // If last line is not partially selected use last but first line
+                if (editor.selection.end.character === 0) {
+                    // Because startLineNumber !== endLineNumber, endLineNumber - 1 >= 0 holds
+                    endLine = doc.lineAt(endLineNumber - 1);
+                } else {
+                    endLine = doc.lineAt(endLineNumber);
+                }
+
+                timePeriod = this._timeCalculator.getTimePeriod(startLine.text, endLine.text);
+            }
 
             if (timePeriod !== undefined) {
 

--- a/src/TimePeriodController.ts
+++ b/src/TimePeriodController.ts
@@ -51,7 +51,7 @@ class TimePeriodController {
             this._statusBarItem.text = '';
 
             const startLineNumber = editor.selection.start.line;
-            let endLineNumber = editor.selection.end.line;
+            const endLineNumber = editor.selection.end.line;
             let timePeriod = undefined;
 
             if (startLineNumber !== endLineNumber) {

--- a/src/TimePeriodController.ts
+++ b/src/TimePeriodController.ts
@@ -1,5 +1,6 @@
 'use strict';
 
+import * as moment from 'moment';
 import * as vscode from 'vscode';
 import TimePeriodCalculator = require('./TimePeriodCalculator');
 
@@ -52,7 +53,7 @@ class TimePeriodController {
 
             const startLineNumber = editor.selection.start.line;
             const endLineNumber = editor.selection.end.line;
-            let timePeriod = undefined;
+            let timePeriod: moment.Duration;
 
             if (startLineNumber !== endLineNumber) {
 


### PR DESCRIPTION
# Issue
If the extension was activated while the first line of a log file was selected the extension crashed, because `vscode.TextDocument.lineAt()` falsely was called with `-1`.

# Changes
* This is now prevent by only triggering the duration calculation if two different lines are selected.
* updated changelog
* bumped version to 2.7.1

# Related Issue
Fixes #91 
