### PR TITLE
Improve matching exception call stacks

### DIFF
--- a/syntaxes/log.tmLanguage
+++ b/syntaxes/log.tmLanguage
@@ -254,7 +254,7 @@
 			<!-- Colorize rows of exception call stacks -->
 			<dict>
 				<key>begin</key>
-				<string>^[\t ]*at</string>
+				<string>^[\t ]*at[\t ]</string>
 
 				<key>end</key>
 				<string>$</string>


### PR DESCRIPTION
Make sure that at is followed by a space or tab to match for call stacks. 

Before: 
<img width="363" alt="image" src="https://github.com/emilast/vscode-logfile-highlighter/assets/6421097/32d55fdf-8770-472a-8d4b-2b330461eb22">

After: 

<img width="345" alt="image" src="https://github.com/emilast/vscode-logfile-highlighter/assets/6421097/56bf441d-0c8f-4492-89eb-d46df76e2716">
