### PR TITLE
Feature/tail mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 **New feature**
 
+* There is now a new **tail mode** feature that is automatically activated by scrolling to the end of a log file. When active, a message will be shown in the status bar: `Log File Tail Mode`. To deactivate, simply scroll up. Fixes feature request #21.
+
+  To disable this feature altogether, set the `logFileHighlighter.enableTailMode` setting to `false`.
+
 ### 3.1.0 - 22 Juni 2024
+
+**New feature**
 
 * There is now a new option for modifying the behavior of custom patterns, the **patternFlags** setting. This setting allows for the use of regular expression flags such as "i" for case-insensitive matching or "s" for multiline matching. Fixes feature requests #87 and #276.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
   To disable this feature altogether, set the `logFileHighlighter.enableTailMode` setting to `false`.
 
+* Also fixed multiple bugs with custom patterns that occurred when a log file was modified, either externally (new log lines being added at the end) or interactive editing of log files (which is an edge case for sure, as log files are generally not modified). The issue was out-of-sync pattern positions.
+
 ### 3.1.0 - 22 Juni 2024
 
 **New feature**

--- a/README.md
+++ b/README.md
@@ -38,6 +38,26 @@ If you select multiple lines of a `.log` file, some simple timestamp analysis is
 
 ![Time Duration Sample](content/TimeAnalysis.gif)  
 
+Settings
+
+* **enableProgressIndicator** can be used to disable the progress indicator feature. The default value is `true`. Set it to `false` to disable the feature.
+
+* **progressIndicatorUnderlineColor** can be used to set the color of the progress indicator. The default value is `#00ff1f8f`. Note the alpha channel value at the end of the color value (`8f`). This can be used to make the color semi-transparent for mixing with the background color.
+
+Example:
+```JSON
+"logFileHighlighter.enableProgressIndicator": true,
+"logFileHighlighter.progressIndicatorUnderlineColor": "#ffee00",
+```
+
+### Tail Mode
+
+The extension also supports a tail mode where the end of the log file is kept in view as new lines are added. To activate it, scroll to the end of the log file until a message is shown in the status bar: `Log File Tail Mode`
+
+To deactivate tail mode for the current file, scroll up again.
+
+This feature can be disabled by setting the `logFileHighlighter.enableTailMode` setting to `false`.
+
 ## Customization
 
 ### Customizing the colors
@@ -81,19 +101,6 @@ To override the color for one of these, use the `editor.tokenColorCustomizations
     ]
 }
 ```
-
-### Time Analysis settings
-
-* **enableProgressIndicator** can be used to disable the progress indicator feature. The default value is `true`. Set it to `false` to disable the feature.
-
-* **progressIndicatorUnderlineColor** can be used to set the color of the progress indicator. The default value is `#00ff1f8f`. Note the alpha channel value at the end of the color value (`8f`). This can be used to make the color semi-transparent for mixing with the background color.
-
-Example:
-```JSON
-"logFileHighlighter.enableProgressIndicator": true,
-"logFileHighlighter.progressIndicatorUnderlineColor": "#ffee00",
-```
-
 
 ### Defining custom highlighting patterns
 

--- a/package.json
+++ b/package.json
@@ -149,6 +149,11 @@
 					"type": "string",
 					"default": "#00ff1f8f",
 					"description": "The color to use for drawing the timestamp progress indicator underline"
+				},
+				"logFileHighlighter.enableTailMode": {
+					"type": "boolean",
+					"default": true,
+					"description": "Enable or disable the tail mode in log files. Scroll to the end of a file to activate it. The status bar will show 'Log File Tail Mode' when it is active."
 				}
 			}
 		}

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,5 +1,5 @@
 export class Constants {
-    public static readonly LOG_ID: string = 'log';
+    public static readonly LogLanguageId: string = 'log';
 
     public static readonly ContextNameIsShowingProgressIndicators = 'logFileHighlighter.isShowingProgressIndicators';
 }

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,0 +1,6 @@
+export class Constants {
+    public static readonly LOG_ID: string = 'log';
+
+    public static readonly ContextNameIsShowingProgressIndicators = 'logFileHighlighter.isShowingProgressIndicators';
+}
+

--- a/src/CustomPatternController.ts
+++ b/src/CustomPatternController.ts
@@ -2,9 +2,9 @@
 
 import * as vscode from 'vscode';
 import { CustomPatternDecorator } from './CustomPatternDecorator';
+import { Constants } from './Constants';
 
 export class CustomPatternController {
-    private readonly LOG_ID: string = 'log';
 
     private _disposable: vscode.Disposable;
     private _decorator: CustomPatternDecorator;
@@ -39,7 +39,7 @@ export class CustomPatternController {
     private onDidChangeConfiguration(): void {
         this._decorator.updateConfiguration();
         const logEditors = vscode.window.visibleTextEditors.filter((editor) => {
-            return editor.document.languageId === this.LOG_ID;
+            return editor.document.languageId === Constants.LOG_ID;
         });
 
         if (logEditors.length !== 0) {
@@ -48,14 +48,14 @@ export class CustomPatternController {
     }
 
     private onDidChangeTextDocument(changedEvent: vscode.TextDocumentChangeEvent) {
-        if (changedEvent.document.languageId === this.LOG_ID) {
+        if (changedEvent.document.languageId === Constants.LOG_ID) {
             this._decorator.decorateDocument(changedEvent);
         }
     }
 
     private onDidChangeVisibleTextEditors(editors: readonly vscode.TextEditor[]) {
         const logEditors = editors.filter((editor) => {
-            return editor.document.languageId === this.LOG_ID;
+            return editor.document.languageId === Constants.LOG_ID;
         });
 
         if (logEditors.length !== 0) {

--- a/src/CustomPatternController.ts
+++ b/src/CustomPatternController.ts
@@ -39,7 +39,7 @@ export class CustomPatternController {
     private onDidChangeConfiguration(): void {
         this._decorator.updateConfiguration();
         const logEditors = vscode.window.visibleTextEditors.filter((editor) => {
-            return editor.document.languageId === Constants.LOG_ID;
+            return editor.document.languageId === Constants.LogLanguageId;
         });
 
         if (logEditors.length !== 0) {
@@ -48,14 +48,14 @@ export class CustomPatternController {
     }
 
     private onDidChangeTextDocument(changedEvent: vscode.TextDocumentChangeEvent) {
-        if (changedEvent.document.languageId === Constants.LOG_ID) {
+        if (changedEvent.document.languageId === Constants.LogLanguageId) {
             this._decorator.decorateDocument(changedEvent);
         }
     }
 
     private onDidChangeVisibleTextEditors(editors: readonly vscode.TextEditor[]) {
         const logEditors = editors.filter((editor) => {
-            return editor.document.languageId === Constants.LOG_ID;
+            return editor.document.languageId === Constants.LogLanguageId;
         });
 
         if (logEditors.length !== 0) {

--- a/src/CustomPatternDecorator.ts
+++ b/src/CustomPatternDecorator.ts
@@ -62,6 +62,7 @@ export class CustomPatternDecorator {
         }
     }
 
+    // As a reaction to a document change, decorate the changed parts with the configured custom patterns.
     public decorateDocument(changedEvent: vscode.TextDocumentChangeEvent): void {
         if (this._configPattern.length === 0 || changedEvent.contentChanges.length === 0) {
             return;
@@ -82,42 +83,47 @@ export class CustomPatternDecorator {
         const contentToEnd: string =
             doc.getText(new vscode.Range(startPos, doc.lineAt(doc.lineCount - 1).range.end));
 
-        for (const logLevel of this._configPattern) {
-            const patternCache = docCache.get(logLevel);
+        for (const pattern of this._configPattern) {
+            const patternCache = docCache.get(pattern);
 
             // Remove all ranges from the cache that occur after the changed range (change.range).
-            const logLevelRanges = patternCache.filter((range) => {
+            const patternRanges = patternCache.filter((range) => {
                 return range.end.isBefore(change.range.start);
             });
 
-            for (const regex of logLevel.regexes) {
+            for (const regex of pattern.regexes) {
                 let matches = regex.exec(contentToEnd);
 
                 while (matches) {
                     var { start, end } = this.getMatchPositions(doc, matches);
-                    logLevelRanges.push(new vscode.Range(start, end));
+                    // Adjust start and end positions to be relative to the whole document.
+                    start = new vscode.Position(start.line + startPos.line, start.character);
+                    end = new vscode.Position(end.line + startPos.line, end.character);
+
+                    patternRanges.push(new vscode.Range(start, end));
                     matches = regex.exec(contentToEnd);
                 }
             }
 
             // Update cache and set decorations.
-            docCache.set(logLevel, logLevelRanges);
-            editors[0].setDecorations(logLevel.decoration, logLevelRanges);
+            docCache.set(pattern, patternRanges);
+            editors[0].setDecorations(pattern.decoration, patternRanges);
         }
 
         this._cache.set(doc.uri, docCache);
     }
 
+    // Apply custom patterns on an array of open files.
     public decorateEditors(editors: vscode.TextEditor[], changes?: vscode.TextDocumentContentChangeEvent[]): void {
         if (editors.length >= 1) {
             for (const editor of editors) {
                 const content = editor.document.getText();
 
                 const docRanges = new Map<CustomPattern, vscode.Range[]>();
-                for (const logLevel of this._configPattern) {
+                for (const pattern of this._configPattern) {
                     const logLevelRanges = [];
 
-                    for (const regex of logLevel.regexes) {
+                    for (const regex of pattern.regexes) {
                         let matches = regex.exec(content);
 
                         while (matches) {
@@ -128,8 +134,8 @@ export class CustomPatternDecorator {
                     }
 
                     // Update cache and set decorations.
-                    editor.setDecorations(logLevel.decoration, logLevelRanges);
-                    docRanges.set(logLevel, logLevelRanges);
+                    editor.setDecorations(pattern.decoration, logLevelRanges);
+                    docRanges.set(pattern, logLevelRanges);
                 }
 
                 this._cache.set(editor.document.uri, docRanges);

--- a/src/CustomPatternDecorator.ts
+++ b/src/CustomPatternDecorator.ts
@@ -95,10 +95,20 @@ export class CustomPatternDecorator {
                 let matches = regex.exec(contentToEnd);
 
                 while (matches) {
-                    var { start, end } = this.getMatchPositions(doc, matches);
+                    var { start, end } = this.getMatchPositionsInContentString(contentToEnd, matches);
+
                     // Adjust start and end positions to be relative to the whole document.
-                    start = new vscode.Position(start.line + startPos.line, start.character);
-                    end = new vscode.Position(end.line + startPos.line, end.character);
+                    if (start.line === 0) {
+                        // First line, so the character position is relative to the start of the change.
+                        start = new vscode.Position(start.line + startPos.line, start.character + startPos.character);
+                        end = new vscode.Position(end.line + startPos.line, end.character + startPos.character);
+                    }
+                    else {
+                        // Not the first line, so the character position is relative to the start of the line,
+                        // which is what getMatchPositionsInContentString() returns.
+                        start = new vscode.Position(start.line + startPos.line, start.character);
+                        end = new vscode.Position(end.line + startPos.line, end.character);
+                    }
 
                     patternRanges.push(new vscode.Range(start, end));
                     matches = regex.exec(contentToEnd);
@@ -127,7 +137,7 @@ export class CustomPatternDecorator {
                         let matches = regex.exec(content);
 
                         while (matches) {
-                            var { start, end } = this.getMatchPositions(editor.document, matches);
+                            var { start, end } = this.getMatchPositionsInDocument(editor.document, matches);
                             logLevelRanges.push(new vscode.Range(start, end));
                             matches = regex.exec(content);
                         }
@@ -143,11 +153,44 @@ export class CustomPatternDecorator {
         }
     }
 
-    private getMatchPositions(document: vscode.TextDocument, matches: RegExpExecArray) {
-        const start = document.positionAt(matches.index);
-        const matchString = matches[0];
-        const newlineCount = (matchString.match(/\n/g) || []).length;
+    // Get the start and end positions of a match in a document. Use this if the document is in a
+    // settled state, i.e. not changing, as when opening a document.
+    private getMatchPositionsInDocument(document: vscode.TextDocument, matches: RegExpExecArray) {
+        const start = document.positionAt(matches.index); // Will give wrong result if the match is on the first line
 
+        const matchString = matches[0];
+
+        // Get end position of the match
+        const newlineCountInMatch = (matchString.match(/\n/g) || []).length;
+        let end = this.getEndPosition(start, newlineCountInMatch, matchString);
+
+        return { start, end };
+    }
+
+    // Get the start and end positions of a match in a content string. Use this if the document is
+    // changing, as when reacting to a document change event.
+    // Note that the positions are relative to the content string, not the whole document.
+    private getMatchPositionsInContentString(content: string, matches: RegExpExecArray) {
+        const matchString = matches[0];
+
+        // Get index of last newline before match in content string
+        const lastNewlineBeforeMatch = content.lastIndexOf('\n', matches.index);
+        const indexWithinMatchLine = matches.index - lastNewlineBeforeMatch - 1;
+
+        // Set the start position of the match within the content string.
+        // The line number is the number of newlines before the match in the content string,
+        // and the character position is the character index of the match within the last line.
+        const newlineCountBeforeMatch = (content.slice(0, matches.index).match(/\n/g) || []).length;
+        let start = new vscode.Position(newlineCountBeforeMatch, indexWithinMatchLine);
+
+        // Set the end position of the match within the content string.
+        const newlineCountInMatch = (matchString.match(/\n/g) || []).length;
+        let end = this.getEndPosition(start, newlineCountInMatch, matchString);
+
+        return { start, end };
+    }
+
+    private getEndPosition(start: vscode.Position, newlineCount: number, matchString: string) {
         let end;
         if (newlineCount === 0) {
             // Match is on the same line
@@ -159,7 +202,7 @@ export class CustomPatternDecorator {
             const lineOffset = newlineCount;
             end = start.translate(lineOffset, lengthOfLastLine);
         }
-        return { start, end };
+        return end;
     }
 
     public dispose() {

--- a/src/ProgressIndicator.ts
+++ b/src/ProgressIndicator.ts
@@ -80,7 +80,7 @@ export class ProgressIndicator {
                 editor.setDecorations(this._decoration, []);
             });
         }
-    
+
         vscode.commands.executeCommand('setContext', Constants.ContextNameIsShowingProgressIndicators, false);
     }
 }

--- a/src/ProgressIndicator.ts
+++ b/src/ProgressIndicator.ts
@@ -2,8 +2,7 @@ import * as vscode from 'vscode';
 import { TimePeriodCalculator } from './TimePeriodCalculator';
 import { SelectionHelper } from './SelectionHelper';
 import moment = require('moment');
-
-const ContextNameIsShowingProgressIndicators = 'logFileHighlighter.isShowingProgressIndicators';
+import { Constants } from './Constants';
 
 export class ProgressIndicator {
 
@@ -70,7 +69,7 @@ export class ProgressIndicator {
 
                 editor.setDecorations(this._decoration, ranges);
 
-                vscode.commands.executeCommand('setContext', ContextNameIsShowingProgressIndicators, true);
+                vscode.commands.executeCommand('setContext', Constants.ContextNameIsShowingProgressIndicators, true);
             }
         }
     }
@@ -81,7 +80,7 @@ export class ProgressIndicator {
                 editor.setDecorations(this._decoration, []);
             });
         }
-
-        vscode.commands.executeCommand('setContext', ContextNameIsShowingProgressIndicators, false);
+    
+        vscode.commands.executeCommand('setContext', Constants.ContextNameIsShowingProgressIndicators, false);
     }
 }

--- a/src/ProgressIndicatorController.ts
+++ b/src/ProgressIndicatorController.ts
@@ -21,7 +21,7 @@ export class ProgressIndicatorController {
         this._progressIndicator.removeAllDecorations();
         this.clearEditorSelections();
     }
-    
+
     private clearEditorSelections() {
         const editor = vscode.window.activeTextEditor;
         if (editor) {

--- a/src/TailController.ts
+++ b/src/TailController.ts
@@ -11,30 +11,49 @@ export class TailController {
 
     constructor() {
 
-        // Create as needed
-        if (!this._statusBarItem) {
-            this._statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+        vscode.workspace.onDidChangeConfiguration(() => { this.onDidChangeConfiguration(); }, this);
+
+        this.init();
+    }
+
+    private init() {
+        const config = this.getConfiguration();
+
+        if (config.enableTailMode) {
+            // Create as needed
+            if (!this._statusBarItem) {
+                this._statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+                this._statusBarItem.tooltip = 'The end of the file is visible, which activates the Log File Highlighter tail mode. When active, the editor will automatically scroll to the end of the file when new lines are added.';
+            }
+
+            // subscribe to selection change and editor activation events
+            const subscriptions: vscode.Disposable[] = [];
+
+            vscode.workspace.onDidChangeTextDocument(event => {
+                this.tailLogFile(event.document);
+            }, this, subscriptions);
+
+            vscode.window.onDidChangeTextEditorVisibleRanges(event => {
+                this.checkEndOfFileVisibilityInActiveEditor();
+            }, this, subscriptions);
+
+            vscode.window.onDidChangeActiveTextEditor(event => {
+                this.editorChanged(event);
+            }, this, subscriptions);
+
+            // create a combined disposable from both event subscriptions
+            this._disposable = vscode.Disposable.from(...subscriptions);
+
+            this.checkEndOfFileVisibilityInActiveEditor();
+        }
+        else {
+            this.dispose
         }
 
-        // subscribe to selection change and editor activation events
-        const subscriptions: vscode.Disposable[] = [];
+    }
 
-        vscode.workspace.onDidChangeTextDocument(event => {
-            this.tailLogFile(event.document);
-        }, this, subscriptions);
-
-        vscode.window.onDidChangeTextEditorVisibleRanges(event => {
-            this.checkEndOfFileVisibilityInActiveEditor();
-        }, this, subscriptions);
-
-        vscode.window.onDidChangeActiveTextEditor(event => {
-            this.editorChanged(event);
-        }, this, subscriptions);
-
-        // create a combined disposable from both event subscriptions
-        this._disposable = vscode.Disposable.from(...subscriptions);
-
-        this.checkEndOfFileVisibilityInActiveEditor();
+    private onDidChangeConfiguration(): void {
+        this.init();
     }
 
     public dispose() {
@@ -42,10 +61,19 @@ export class TailController {
         this._disposable.dispose();
     }
 
+    private getConfiguration(): { enableTailMode: boolean } {
+        const config = vscode.workspace.getConfiguration('logFileHighlighter');
+
+        const enableTailMode = config.get('enableTailMode', true);
+
+        return {
+            enableTailMode
+        };
+    }
     private checkEndOfFileVisibilityInActiveEditor() {
         const textEditor = vscode.window.activeTextEditor;
         const visibleRanges = vscode.window.activeTextEditor.visibleRanges
-        
+
         if (textEditor?.document.languageId === 'log') {
             const lastLine = textEditor.document.lineCount - 1;
             const lastVisibleRange = visibleRanges[0].end.line;
@@ -53,9 +81,9 @@ export class TailController {
             if (lastVisibleRange >= lastLine) {
                 // The end of the file is visible
                 this._tailModeActive = true;
-                this._statusBarItem.text = 'Log file tail mode';
+                this._statusBarItem.text = 'Log File Tail Mode';
                 this._statusBarItem.show();
-                
+
                 return;
             }
         }
@@ -70,13 +98,14 @@ export class TailController {
     }
 
     private tailLogFile(document: vscode.TextDocument) {
-        if (this._tailModeActive) {
+        // Check if tail mode is active and the document is the active editor
+        if (this._tailModeActive && vscode.window.activeTextEditor?.document === document) {
             // Get the last line number
             const lastLine = document.lineCount - 1;
             const range = new vscode.Range(lastLine, 0, lastLine, 0);
 
             // Scroll to the last line
-            vscode.window.activeTextEditor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+            vscode.window.activeTextEditor.revealRange(range, vscode.TextEditorRevealType.InCenterIfOutsideViewport);
         }
     }
 }

--- a/src/TailController.ts
+++ b/src/TailController.ts
@@ -1,0 +1,82 @@
+'use strict';
+
+import * as vscode from 'vscode';
+
+export class TailController {
+
+    private _disposable: vscode.Disposable;
+    private _statusBarItem: vscode.StatusBarItem;
+
+    private _tailModeActive: boolean = false;
+
+    constructor() {
+
+        // Create as needed
+        if (!this._statusBarItem) {
+            this._statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+        }
+
+        // subscribe to selection change and editor activation events
+        const subscriptions: vscode.Disposable[] = [];
+
+        vscode.workspace.onDidChangeTextDocument(event => {
+            this.tailLogFile(event.document);
+        }, this, subscriptions);
+
+        vscode.window.onDidChangeTextEditorVisibleRanges(event => {
+            this.checkEndOfFileVisibilityInActiveEditor();
+        }, this, subscriptions);
+
+        vscode.window.onDidChangeActiveTextEditor(event => {
+            this.editorChanged(event);
+        }, this, subscriptions);
+
+        // create a combined disposable from both event subscriptions
+        this._disposable = vscode.Disposable.from(...subscriptions);
+
+        this.checkEndOfFileVisibilityInActiveEditor();
+    }
+
+    public dispose() {
+        this._statusBarItem.dispose();
+        this._disposable.dispose();
+    }
+
+    private checkEndOfFileVisibilityInActiveEditor() {
+        const textEditor = vscode.window.activeTextEditor;
+        const visibleRanges = vscode.window.activeTextEditor.visibleRanges
+        
+        if (textEditor?.document.languageId === 'log') {
+            const lastLine = textEditor.document.lineCount - 1;
+            const lastVisibleRange = visibleRanges[0].end.line;
+
+            if (lastVisibleRange >= lastLine) {
+                // The end of the file is visible
+                this._tailModeActive = true;
+                this._statusBarItem.text = 'Log file tail mode';
+                this._statusBarItem.show();
+                
+                return;
+            }
+        }
+
+        // Else: Not a log file, or the end of the file is not visible => no tail mode
+        this._tailModeActive = false;
+        this._statusBarItem.hide();
+    }
+
+    editorChanged(event: vscode.TextEditor) {
+        this.checkEndOfFileVisibilityInActiveEditor();
+    }
+
+    private tailLogFile(document: vscode.TextDocument) {
+        if (this._tailModeActive) {
+            // Get the last line number
+            const lastLine = document.lineCount - 1;
+            const range = new vscode.Range(lastLine, 0, lastLine, 0);
+
+            // Scroll to the last line
+            vscode.window.activeTextEditor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+        }
+    }
+}

--- a/src/TailController.ts
+++ b/src/TailController.ts
@@ -75,7 +75,7 @@ export class TailController {
         const textEditor = vscode.window.activeTextEditor;
         const visibleRanges = vscode.window.activeTextEditor.visibleRanges
 
-        if (textEditor?.document.languageId === Constants.LOG_ID) {
+        if (textEditor?.document.languageId === Constants.LogLanguageId) {
             const lastLine = textEditor.document.lineCount - 1;
             const lastVisibleRange = visibleRanges[0].end.line;
 

--- a/src/TailController.ts
+++ b/src/TailController.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import * as vscode from 'vscode';
+import { Constants } from './Constants';
 
 export class TailController {
 
@@ -74,7 +75,7 @@ export class TailController {
         const textEditor = vscode.window.activeTextEditor;
         const visibleRanges = vscode.window.activeTextEditor.visibleRanges
 
-        if (textEditor?.document.languageId === 'log') {
+        if (textEditor?.document.languageId === Constants.LOG_ID) {
             const lastLine = textEditor.document.lineCount - 1;
             const lastVisibleRange = visibleRanges[0].end.line;
 

--- a/src/TimePeriodController.ts
+++ b/src/TimePeriodController.ts
@@ -3,6 +3,7 @@
 import * as vscode from 'vscode';
 import { TimePeriodCalculator } from './TimePeriodCalculator';
 import { SelectionHelper } from './SelectionHelper';
+import { Constants } from './Constants';
 
 export class TimePeriodController {
 
@@ -49,7 +50,7 @@ export class TimePeriodController {
         const doc = editor.document;
 
         // Only update status if an log file
-        if (doc.languageId === 'log') {
+        if (doc.languageId === Constants.LOG_ID) {
 
             this._statusBarItem.text = '';
 

--- a/src/TimePeriodController.ts
+++ b/src/TimePeriodController.ts
@@ -50,7 +50,7 @@ export class TimePeriodController {
         const doc = editor.document;
 
         // Only update status if an log file
-        if (doc.languageId === Constants.LOG_ID) {
+        if (doc.languageId === Constants.LogLanguageId) {
 
             this._statusBarItem.text = '';
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { ProgressIndicatorController } from './ProgressIndicatorController';
 import { SelectionHelper } from './SelectionHelper';
 import { TimePeriodCalculator } from './TimePeriodCalculator';
 import { TimePeriodController } from './TimePeriodController';
+import { TailController } from './TailController';
 
 // this method is called when the extension is activated
 export function activate(context: vscode.ExtensionContext) {
@@ -26,6 +27,9 @@ export function activate(context: vscode.ExtensionContext) {
     const progressIndicator = new ProgressIndicator(timeCalculator, selectionHelper);
     const progressIndicatorController = new ProgressIndicatorController(progressIndicator);
 
+    // tail log files
+    const tailController = new TailController();
+
     // register commands
     context.subscriptions.push(
         vscode.commands.registerCommand(
@@ -35,7 +39,7 @@ export function activate(context: vscode.ExtensionContext) {
             }));
 
     // Add to a list of disposables which are disposed when this extension is deactivated.
-    context.subscriptions.push(timeController, customPatternController, progressIndicatorController);
+    context.subscriptions.push(timeController, customPatternController, progressIndicatorController, tailController);
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
Implements a new **tail mode** feature that was requested a long time ago in #21. Tail mode is automatically activated by scrolling to the end of a log file. When active, a message will be shown in the status bar: `Log File Tail Mode`. To deactivate, simply scroll up.

When active, the last line of the file will be kept in view as new lines are added.

To disable this feature altogether, set the `logFileHighlighter.enableTailMode` setting to `false`.

This PR also fixes multiple bugs with custom patterns that occurred when a log file was modified, either externally (new log lines being added at the end) or interactive editing of log files (which is an edge case for sure, as log files are generally not modified). The issue was out-of-sync pattern positions.

Fixes #21.