### PR TITLE
Added support for microsecond precision for timestamps 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+**New features**
+
+* Added support for microsecond precision for timestamps.
+
+  Example timestamp: `2023-09-26 18:24:17.035169`
+
+  Before this change, only millisecond precision was supported, so the last three digits in the timestamp above was lost. This was caused by limited time precision support in Javascript and the new microsecond precision has required explicit handling in the extension to keep track of the number of microseconds.
+
+  Fixes #65 and #594.
+
 ### 3.2.0 - 30 June 2024
 
 **New features**

--- a/src/ProgressIndicator.ts
+++ b/src/ProgressIndicator.ts
@@ -42,6 +42,9 @@ export class ProgressIndicator {
                 let timestampStartIndex = this._timeCalculator.getTimestampFromText(texts.endLine).matchIndex;
                 let timestampWidth = this._timeCalculator.getTimestampFromText(texts.endLine).original.length;
 
+                const totalPeriodDurationInMicroseconds = timePeriod.duration.asMilliseconds() * 1000 + timePeriod.durationMicroseconds;
+                const startTimeInMicroseconds = timePeriod.startTime.time.valueOf() * 1000 + timePeriod.startTime.microseconds;
+
                 // Iterate over all lines in the selection and decorate them according to their progress
                 // (i.e. how far they are from the start time of the selection to the end time of the selection)
                 let ranges: vscode.Range[] = [];
@@ -50,9 +53,8 @@ export class ProgressIndicator {
 
                     var timestamp = this._timeCalculator.getTimestampFromText(lineText);
                     if (timestamp) {
-
-                        var ts = moment(timestamp.iso);
-                        var progress = ts.diff(timePeriod.startTime) / timePeriod.duration.asMilliseconds();
+                        var timestampInMicroseconds = moment(timestamp.iso).valueOf() * 1000 + timestamp.microseconds;
+                        var progress = (timestampInMicroseconds - startTimeInMicroseconds) / totalPeriodDurationInMicroseconds;
 
                         // Max progress = length of timestamp
                         var decorationCharacterCount = Math.floor(timestampWidth * progress);

--- a/src/ProgressIndicator.ts
+++ b/src/ProgressIndicator.ts
@@ -3,7 +3,7 @@ import { TimePeriodCalculator } from './TimePeriodCalculator';
 import { SelectionHelper } from './SelectionHelper';
 import moment = require('moment');
 import { Constants } from './Constants';
-import { TimeWithMicroseconds } from './TimePeriod';
+import { TimeWithMicroseconds } from './TimeWithMicroseconds';
 
 export class ProgressIndicator {
 

--- a/src/ProgressIndicator.ts
+++ b/src/ProgressIndicator.ts
@@ -3,6 +3,7 @@ import { TimePeriodCalculator } from './TimePeriodCalculator';
 import { SelectionHelper } from './SelectionHelper';
 import moment = require('moment');
 import { Constants } from './Constants';
+import { TimeWithMicroseconds } from './TimePeriod';
 
 export class ProgressIndicator {
 
@@ -42,8 +43,8 @@ export class ProgressIndicator {
                 let timestampStartIndex = this._timeCalculator.getTimestampFromText(texts.endLine).matchIndex;
                 let timestampWidth = this._timeCalculator.getTimestampFromText(texts.endLine).original.length;
 
-                const totalPeriodDurationInMicroseconds = timePeriod.duration.asMilliseconds() * 1000 + timePeriod.durationMicroseconds;
-                const startTimeInMicroseconds = timePeriod.startTime.time.valueOf() * 1000 + timePeriod.startTime.microseconds;
+                const durationInMicroseconds = timePeriod.getDurationAsMicroseconds();
+                const startTimeAsEpoch = timePeriod.startTime.getTimeAsEpoch();
 
                 // Iterate over all lines in the selection and decorate them according to their progress
                 // (i.e. how far they are from the start time of the selection to the end time of the selection)
@@ -53,8 +54,8 @@ export class ProgressIndicator {
 
                     var timestamp = this._timeCalculator.getTimestampFromText(lineText);
                     if (timestamp) {
-                        var timestampInMicroseconds = moment(timestamp.iso).valueOf() * 1000 + timestamp.microseconds;
-                        var progress = (timestampInMicroseconds - startTimeInMicroseconds) / totalPeriodDurationInMicroseconds;
+                        let timestampWithMicroseconds = new TimeWithMicroseconds(moment(timestamp.iso), timestamp.microseconds);
+                        var progress = (timestampWithMicroseconds.getTimeAsEpoch() - startTimeAsEpoch) / durationInMicroseconds;
 
                         // Max progress = length of timestamp
                         var decorationCharacterCount = Math.floor(timestampWidth * progress);

--- a/src/SelectionHelper.ts
+++ b/src/SelectionHelper.ts
@@ -1,7 +1,5 @@
 'use strict';
 import * as vscode from 'vscode';
-import { TimePeriod } from './TimePeriod';
-
 
 export class SelectionHelper {
     getFirstAndLastLines(editor: vscode.TextEditor, doc: vscode.TextDocument) {

--- a/src/TimePeriod.ts
+++ b/src/TimePeriod.ts
@@ -5,7 +5,9 @@ export class TimePeriod {
     startTime: TimeWithMicroseconds;
     endTime: TimeWithMicroseconds;
     duration: moment.Duration;
-    durationMicroseconds: number;
+    
+    // The microsecond part of the duration
+    durationPartMicroseconds: number;
 
     constructor(startTime: TimeWithMicroseconds, endTime: TimeWithMicroseconds,
         duration: moment.Duration) {
@@ -14,13 +16,18 @@ export class TimePeriod {
 
         if (endTime.microseconds >= startTime.microseconds) {
             this.duration = duration;
-            this.durationMicroseconds = endTime.microseconds - startTime.microseconds;
+            this.durationPartMicroseconds = endTime.microseconds - startTime.microseconds;
         }
         else {
             this.duration = duration.subtract(1, 'milliseconds');
-            this.durationMicroseconds = 1000 + endTime.microseconds - startTime.microseconds;
+            this.durationPartMicroseconds = 1000 + endTime.microseconds - startTime.microseconds;
         }
     }
+
+    public getDurationAsMicroseconds(): number {
+        return this.duration.asMilliseconds() * 1000 + this.durationPartMicroseconds;
+    }
+
 }
 
 export class TimeWithMicroseconds {
@@ -30,5 +37,9 @@ export class TimeWithMicroseconds {
     constructor(time: moment.Moment, microseconds: number | undefined) {
         this.time = time;
         this.microseconds = microseconds || 0;
+    }
+
+    public getTimeAsEpoch(): number {
+        return this.time.valueOf() * 1000 + this.microseconds;
     }
 }

--- a/src/TimePeriod.ts
+++ b/src/TimePeriod.ts
@@ -5,22 +5,54 @@ export class TimePeriod {
     startTime: TimeWithMicroseconds;
     endTime: TimeWithMicroseconds;
     duration: moment.Duration;
-    
+
     // The microsecond part of the duration
     durationPartMicroseconds: number;
 
-    constructor(startTime: TimeWithMicroseconds, endTime: TimeWithMicroseconds,
-        duration: moment.Duration) {
-        this.startTime = startTime;
-        this.endTime = endTime;
+    constructor(
+        startTimeMatch: { iso: string, microseconds: number },
+        endTimeMatch: { iso: string, microseconds: number }) {
 
-        if (endTime.microseconds >= startTime.microseconds) {
-            this.duration = duration;
-            this.durationPartMicroseconds = endTime.microseconds - startTime.microseconds;
+        this.startTime = new TimeWithMicroseconds(moment(startTimeMatch.iso), startTimeMatch.microseconds);
+        this.endTime = new TimeWithMicroseconds(moment(endTimeMatch.iso), endTimeMatch.microseconds);
+        this.duration = this.calculateDuration(startTimeMatch, endTimeMatch);
+
+        this.adjustDurationWithMicroseconds();
+    }
+
+    private calculateDuration(
+        startTime: { iso: string; microseconds: number; },
+        endTime: { iso: string; microseconds: number; })
+        : moment.Duration {
+
+        let duration: moment.Duration;
+
+        const firstMoment = moment(startTime.iso);
+        const lastMoment = moment(endTime.iso);
+
+        if (firstMoment.isValid() && lastMoment.isValid()) {
+            // used for ISO Dates like '2018-09-29' and '2018-09-29 13:12:11.001'
+            duration = moment.duration(lastMoment.diff(firstMoment));
+        } else {
+            // Handle the case where only times are present (no dates) by treating them as durations
+            const firstDuration = moment.duration(startTime.iso);
+            const lastDuration = moment.duration(endTime.iso);
+
+            if (moment.isDuration(firstDuration) && moment.isDuration(lastDuration)) {
+                // Used for non ISO dates like '13:12:11.001'
+                duration = moment.duration(lastDuration.asMilliseconds() - firstDuration.asMilliseconds());
+            }
+        }
+        return duration;
+    }
+
+    private adjustDurationWithMicroseconds() {
+        if (this.endTime.microseconds >= this.startTime.microseconds) {
+            this.durationPartMicroseconds = this.endTime.microseconds - this.startTime.microseconds;
         }
         else {
-            this.duration = duration.subtract(1, 'milliseconds');
-            this.durationPartMicroseconds = 1000 + endTime.microseconds - startTime.microseconds;
+            this.duration = this.duration.subtract(1, 'milliseconds');
+            this.durationPartMicroseconds = 1000 + this.endTime.microseconds - this.startTime.microseconds;
         }
     }
 

--- a/src/TimePeriod.ts
+++ b/src/TimePeriod.ts
@@ -2,13 +2,33 @@
 import * as moment from 'moment';
 
 export class TimePeriod {
-    startTime: moment.Moment;
-    endTime: moment.Moment;
+    startTime: TimeWithMicroseconds;
+    endTime: TimeWithMicroseconds;
     duration: moment.Duration;
+    durationMicroseconds: number;
 
-    constructor(startTime: moment.Moment, endTime: moment.Moment, duration: moment.Duration) {
+    constructor(startTime: TimeWithMicroseconds, endTime: TimeWithMicroseconds,
+        duration: moment.Duration) {
         this.startTime = startTime;
         this.endTime = endTime;
-        this.duration = duration;
+
+        if (endTime.microseconds >= startTime.microseconds) {
+            this.duration = duration;
+            this.durationMicroseconds = endTime.microseconds - startTime.microseconds;
+        }
+        else {
+            this.duration = duration.subtract(1, 'milliseconds');
+            this.durationMicroseconds = 1000 + endTime.microseconds - startTime.microseconds;
+        }
+    }
+}
+
+export class TimeWithMicroseconds {
+    time: moment.Moment;
+    microseconds: number;
+
+    constructor(time: moment.Moment, microseconds: number | undefined) {
+        this.time = time;
+        this.microseconds = microseconds || 0;
     }
 }

--- a/src/TimePeriodCalculator.ts
+++ b/src/TimePeriodCalculator.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import * as moment from 'moment';
-import { TimePeriod, TimeWithMicroseconds } from './TimePeriod';
+import { TimePeriod } from './TimePeriod';
 
 export class TimePeriodCalculator {
 

--- a/src/TimePeriodCalculator.ts
+++ b/src/TimePeriodCalculator.ts
@@ -1,45 +1,49 @@
 'use strict';
 
 import * as moment from 'moment';
-import { TimePeriod } from './TimePeriod';
+import { TimePeriod, TimeWithMicroseconds } from './TimePeriod';
 
 export class TimePeriodCalculator {
 
     // Converts a given moment.Duration to a string that can be displayed.
-    public convertToDisplayString(selectedDuration: moment.Duration): string {
+    public convertToDisplayString(selectedDuration: TimePeriod): string {
         let text = '';
 
-        if (selectedDuration.asDays() >= 1) {
-            text += Math.floor(selectedDuration.asDays()) + 'd';
+        if (selectedDuration.duration.asDays() >= 1) {
+            text += Math.floor(selectedDuration.duration.asDays()) + 'd';
         }
         if (text !== '') {
-            text += ', ' + selectedDuration.hours() + 'h';
-        } else if (selectedDuration.hours() !== 0) {
-            text += selectedDuration.hours() + 'h';
+            text += ', ' + selectedDuration.duration.hours() + 'h';
+        } else if (selectedDuration.duration.hours() !== 0) {
+            text += selectedDuration.duration.hours() + 'h';
         }
         if (text !== '') {
-            text += ', ' + selectedDuration.minutes() + 'min';
-        } else if (selectedDuration.minutes() !== 0) {
-            text += selectedDuration.minutes() + 'min';
+            text += ', ' + selectedDuration.duration.minutes() + 'min';
+        } else if (selectedDuration.duration.minutes() !== 0) {
+            text += selectedDuration.duration.minutes() + 'min';
         }
         if (text !== '') {
-            text += ', ' + selectedDuration.seconds() + 's';
-        } else if (selectedDuration.seconds() !== 0) {
-            text += selectedDuration.seconds() + 's';
+            text += ', ' + selectedDuration.duration.seconds() + 's';
+        } else if (selectedDuration.duration.seconds() !== 0) {
+            text += selectedDuration.duration.seconds() + 's';
         }
         if (text !== '') {
-            text += ', ' + selectedDuration.milliseconds() + 'ms';
+            text += ', ' + selectedDuration.duration.milliseconds() + 'ms';
+        } else if (selectedDuration.duration.milliseconds() !== 0) {
+            text += selectedDuration.duration.milliseconds() + 'ms';
+        }
+        if (text !== '') {
+            text += ', ' + selectedDuration.durationMicroseconds + 'μs';
         } else {
-            text += selectedDuration.milliseconds() + 'ms';
+            text += selectedDuration.durationMicroseconds + 'μs';
         }
-
         text = 'Selected: ' + text;
 
         return text;
     }
 
-    public getTimestampFromText(text: string) : { original: string, matchIndex: number, iso: string } {
-        const clockPattern = '\\d{2}:\\d{2}(?::\\d{2}(?:[.,]\\d{3,})?)?(?:Z| ?[+-]\\d{2}:\\d{2})?\\b';
+    public getTimestampFromText(text: string): { original: string, matchIndex: number, iso: string, microseconds: number } {
+        const clockPattern = '\\d{2}:\\d{2}(?::\\d{2}(?:[.,]\\d{3}(\\d{3})?)?)?(?:Z| ?[+-]\\d{2}:\\d{2})?\\b';
 
         // ISO dates ("2016-08-23")
         const isoDatePattern = '\\d{4}-\\d{2}-\\d{2}(?:T|\\b)';
@@ -64,8 +68,20 @@ export class TimePeriodCalculator {
             // Get the first match for both lines
             const match = timeRegEx.exec(text);
 
+            const microsecondsMatch = match[2];
+
             if (match) {
-                return { original: match[0], matchIndex: match.index, iso: this._convertToIso(match[0]) };
+                let microseconds = 0;
+
+                if (microsecondsMatch) {
+                    microseconds = parseInt(microsecondsMatch);
+                }
+                return {
+                    original: match[0],
+                    matchIndex: match.index,
+                    iso: this._convertToIso(match[0]),
+                    microseconds: microseconds
+                };
             }
         }
 
@@ -73,35 +89,33 @@ export class TimePeriodCalculator {
     }
 
     public getTimePeriod(firstLine: string, lastLine: string): TimePeriod {
-        let firstLineMatch = this.getTimestampFromText(firstLine).iso;
-        let lastLineMatch = this.getTimestampFromText(lastLine).iso;
+        let firstLineMatch = this.getTimestampFromText(firstLine);
+        let lastLineMatch = this.getTimestampFromText(lastLine);
 
-        let timePeriod: moment.Duration;
-        timePeriod = undefined;
+        let duration: moment.Duration;
+        duration = undefined;
 
         if (firstLineMatch && lastLineMatch) {
-            const firstMoment = moment(firstLineMatch);
-            const lastMoment = moment(lastLineMatch);
-        
+            const firstMoment = moment(firstLineMatch.iso);
+            const lastMoment = moment(lastLineMatch.iso);
+
             if (firstMoment.isValid() && lastMoment.isValid()) {
                 // used for ISO Dates like '2018-09-29' and '2018-09-29 13:12:11.001'
-                timePeriod = moment.duration(lastMoment.diff(firstMoment));
+                duration = moment.duration(lastMoment.diff(firstMoment));
             } else {
-                const firstDuration = moment.duration(firstLineMatch);
-                const lastDuration = moment.duration(lastLineMatch);
-        
+                const firstDuration = moment.duration(firstLineMatch.iso);
+                const lastDuration = moment.duration(lastLineMatch.iso);
+
                 if (moment.isDuration(firstDuration) && moment.isDuration(lastDuration)) {
                     // Used for non ISO dates like '13:12:11.001'
-                    timePeriod = moment.duration(lastDuration.asMilliseconds() - firstDuration.asMilliseconds());
+                    duration = moment.duration(lastDuration.asMilliseconds() - firstDuration.asMilliseconds());
                 }
             }
 
-            return {
-                startTime: firstMoment,
-                endTime: lastMoment,
-                duration: timePeriod
-            };
-
+            return new TimePeriod(
+                new TimeWithMicroseconds(firstMoment, firstLineMatch.microseconds),
+                new TimeWithMicroseconds(lastMoment, lastLineMatch.microseconds),
+                duration);
         }
 
         return undefined

--- a/src/TimePeriodCalculator.ts
+++ b/src/TimePeriodCalculator.ts
@@ -93,33 +93,11 @@ export class TimePeriodCalculator {
         let firstLineMatch = this.getTimestampFromText(firstLine);
         let lastLineMatch = this.getTimestampFromText(lastLine);
 
-        let duration: moment.Duration;
-        duration = undefined;
-
         if (firstLineMatch && lastLineMatch) {
-            const firstMoment = moment(firstLineMatch.iso);
-            const lastMoment = moment(lastLineMatch.iso);
-
-            if (firstMoment.isValid() && lastMoment.isValid()) {
-                // used for ISO Dates like '2018-09-29' and '2018-09-29 13:12:11.001'
-                duration = moment.duration(lastMoment.diff(firstMoment));
-            } else {
-                const firstDuration = moment.duration(firstLineMatch.iso);
-                const lastDuration = moment.duration(lastLineMatch.iso);
-
-                if (moment.isDuration(firstDuration) && moment.isDuration(lastDuration)) {
-                    // Used for non ISO dates like '13:12:11.001'
-                    duration = moment.duration(lastDuration.asMilliseconds() - firstDuration.asMilliseconds());
-                }
-            }
-
-            return new TimePeriod(
-                new TimeWithMicroseconds(firstMoment, firstLineMatch.microseconds),
-                new TimeWithMicroseconds(lastMoment, lastLineMatch.microseconds),
-                duration);
+            return new TimePeriod(firstLineMatch, lastLineMatch);
         }
 
-        return undefined
+        return undefined;
     }
 
     // Converts a given date string to an iso string.

--- a/src/TimePeriodController.ts
+++ b/src/TimePeriodController.ts
@@ -12,7 +12,7 @@ export class TimePeriodController {
     private _disposable: vscode.Disposable;
     private _statusBarItem: vscode.StatusBarItem;
 
-    constructor(timeCalculator: TimePeriodCalculator, selectionHelper: SelectionHelper ) {
+    constructor(timeCalculator: TimePeriodCalculator, selectionHelper: SelectionHelper) {
         this._timeCalculator = timeCalculator;
         this._selectionHelper = selectionHelper;
 
@@ -61,7 +61,7 @@ export class TimePeriodController {
                 if (timePeriod !== undefined) {
 
                     // Update the status bar
-                    this._statusBarItem.text = this._timeCalculator.convertToDisplayString(timePeriod.duration);
+                    this._statusBarItem.text = this._timeCalculator.convertToDisplayString(timePeriod);
                     this._statusBarItem.show();
 
                 } else {

--- a/src/TimeWithMicroseconds.ts
+++ b/src/TimeWithMicroseconds.ts
@@ -1,0 +1,13 @@
+export class TimeWithMicroseconds {
+    time: moment.Moment;
+    microseconds: number;
+
+    constructor(time: moment.Moment, microseconds: number | undefined) {
+        this.time = time;
+        this.microseconds = microseconds || 0;
+    }
+
+    public getTimeAsEpoch(): number {
+        return this.time.valueOf() * 1000 + this.microseconds;
+    }
+}

--- a/test/unittest/TimePeriod.test.ts
+++ b/test/unittest/TimePeriod.test.ts
@@ -1,0 +1,34 @@
+'use strict';
+
+import * as moment from 'moment';
+import { TimePeriod, TimeWithMicroseconds } from '../../src/TimePeriod';
+
+describe('TimePeriod', () => {
+    describe('duration', () => {
+        it('gets the correct duration when full dates are present.', () => {
+            // Arrange
+            const startTime = {iso: '2024-02-03 12:13:14', microseconds: 0};
+            const endTime = {iso: '2024-02-03 12:13:15', microseconds: 0};
+
+            // Act
+            const result = new TimePeriod(startTime, endTime);
+
+            // Assert
+            expect(result.duration).toEqual(moment.duration({ seconds: 1 }));
+            expect(result.durationPartMicroseconds).toBe(0);
+        });
+
+        it('gets the correct duration when only times are (no dates).', () => {
+            // Arrange
+            const startTime = {iso: '12:13:14', microseconds: 0};
+            const endTime = {iso: '12:13:15', microseconds: 0};
+
+            // Act
+            const result = new TimePeriod(startTime, endTime);
+
+            // Assert
+            expect(result.duration).toEqual(moment.duration({ seconds: 1 }));
+            expect(result.durationPartMicroseconds).toBe(0);
+        });
+    });
+});

--- a/test/unittest/TimePeriod.test.ts
+++ b/test/unittest/TimePeriod.test.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import * as moment from 'moment';
-import { TimePeriod, TimeWithMicroseconds } from '../../src/TimePeriod';
+import { TimePeriod } from '../../src/TimePeriod';
 
 describe('TimePeriod', () => {
     describe('duration', () => {
@@ -29,6 +29,34 @@ describe('TimePeriod', () => {
             // Assert
             expect(result.duration).toEqual(moment.duration({ seconds: 1 }));
             expect(result.durationPartMicroseconds).toBe(0);
+            expect(result.startTime.time).toBeUndefined(); // Not set when date is missing
+            expect(result.endTime.time).toBeUndefined(); // Not set when date is missing
+        });
+
+        it('gets the correct duration with microseconds.', () => {
+            // Arrange
+            const startTime = {iso: '2024-02-03 12:13:14.100', microseconds: 1};
+            const endTime = {iso: '2024-02-03 12:13:15.200', microseconds: 10};
+
+            // Act
+            const result = new TimePeriod(startTime, endTime);
+
+            // Assert
+            expect(result.duration).toEqual(moment.duration({ seconds: 1, milliseconds: 100 }));
+            expect(result.durationPartMicroseconds).toBe(9);
+        });
+
+        it('gets the correct duration with negative microseconds.', () => {
+            // Arrange
+            const startTime = {iso: '2024-02-03 12:13:14.100', microseconds: 10};
+            const endTime = {iso: '2024-02-03 12:13:14.200', microseconds: 1};
+
+            // Act
+            const result = new TimePeriod(startTime, endTime);
+
+            // Assert
+            expect(result.duration).toEqual(moment.duration({ seconds: 0, milliseconds: 99 }));
+            expect(result.durationPartMicroseconds).toBe(991);
         });
     });
 });

--- a/test/unittest/TimePeriodCalculator.test.ts
+++ b/test/unittest/TimePeriodCalculator.test.ts
@@ -11,7 +11,35 @@ describe('TimePeriodCalculator', () => {
     });
 
     describe('getTimeStampFromText', () => {
-        it('gets the correct timePeriod from "hh:mm:ss.ssssss".', () => {
+        it('gets the correct timestamp from "YYYY-MM-DD".', () => {
+            // Arrange
+            const text = '2024-01-23 first line';
+
+            // Act
+            const result = testObject.getTimestampFromText(text);
+
+            // Assert
+            expect(result.iso).toBe('2024-01-23');
+            expect(result.matchIndex).toBe(0);
+            expect(result.original).toBe('2024-01-23');
+            expect(result.microseconds).toBe(0);
+        });
+
+        it('gets the correct timestamp from "YYYY-MM-DD hh:mm".', () => {
+            // Arrange
+            const text = '2024-01-23 10:38 first line';
+
+            // Act
+            const result = testObject.getTimestampFromText(text);
+
+            // Assert
+            expect(result.iso).toBe('2024-01-23 10:38');
+            expect(result.matchIndex).toBe(0);
+            expect(result.original).toBe('2024-01-23 10:38');
+            expect(result.microseconds).toBe(0);
+        });
+
+        it('gets the correct timestamp from "hh:mm:ss.ssssss".', () => {
             // Arrange
             const text = '10:11:12.100123 first line';
 
@@ -25,7 +53,7 @@ describe('TimePeriodCalculator', () => {
             expect(result.microseconds).toBe(123);
         });
 
-        it('gets the correct timePeriod from "YYYY-MM-DD hh:mm:ss.ssssss".', () => {
+        it('gets the correct timestamp from "YYYY-MM-DD hh:mm:ss.ssssss".', () => {
             // Arrange
             const text = '2024-01-23 10:11:12.100123 first line';
 
@@ -38,11 +66,118 @@ describe('TimePeriodCalculator', () => {
             expect(result.original).toBe('2024-01-23 10:11:12.100123');
             expect(result.microseconds).toBe(123);
         });
+
+        it('gets the correct timestamp from "DD.MM.YYYY".', () => {
+            // Arrange
+            const text = '28.02.2020 first line';
+
+            // Act
+            const result = testObject.getTimestampFromText(text);
+
+            // Assert
+            expect(result.iso).toBe('2020-02-28');
+            expect(result.matchIndex).toBe(0);
+            expect(result.original).toBe('28.02.2020');
+            expect(result.microseconds).toBe(0);
+        });
+
+        it('gets the correct timestamp from "DD.MM.YYYY hh:mm".', () => {
+            // Arrange
+            const text = '28.02.2020 16:51 first line';
+
+            // Act
+            const result = testObject.getTimestampFromText(text);
+
+            // Assert
+            expect(result.iso).toBe('2020-02-28 16:51');
+            expect(result.matchIndex).toBe(0);
+            expect(result.original).toBe('28.02.2020 16:51');
+            expect(result.microseconds).toBe(0);
+        });
+
+        it('gets the correct timestamp from "YYYY-MM-DDThh:mm:ss.sssZ".', () => {
+            // Arrange
+            const text = '2018-01-27T10:38:28.935Z first line';
+
+            // Act
+            const result = testObject.getTimestampFromText(text);
+
+            // Assert
+            expect(result.iso).toBe('2018-01-27T10:38:28.935Z');
+            expect(result.matchIndex).toBe(0);
+            expect(result.original).toBe('2018-01-27T10:38:28.935Z');
+            expect(result.microseconds).toBe(0);
+        });
+
+        it('gets the correct timestamp from "DD/MM/YYY hh:mm:ss,sss".', () => {
+            // Arrange
+            const text = '28/02/2020 16:51:29,001 first line';
+
+            // Act
+            const result = testObject.getTimestampFromText(text);
+
+            // Assert
+            expect(result.iso).toBe('2020-02-28 16:51:29.001');
+            expect(result.matchIndex).toBe(0);
+            expect(result.original).toBe('28/02/2020 16:51:29,001');
+            expect(result.microseconds).toBe(0);
+        });
+
+        it('gets the correct timestamp from "DD/MM/YYY hh:mm:ss,ssssss".', () => {
+            // Arrange
+            const text = '28/02/2020 16:51:29,001234 first line';
+
+            // Act
+            const result = testObject.getTimestampFromText(text);
+
+            // Assert
+            expect(result.iso).toBe('2020-02-28 16:51:29.001234');
+            expect(result.matchIndex).toBe(0);
+            expect(result.original).toBe('28/02/2020 16:51:29,001234');
+            expect(result.microseconds).toBe(234);
+        });
+
+        it('gets the correct matchIndex.', () => {
+            // Arrange
+            const text = 'abc 2024-01-23 first line';
+
+            // Act
+            const result = testObject.getTimestampFromText(text);
+
+            // Assert
+            expect(result.iso).toBe('2024-01-23');
+            expect(result.matchIndex).toBe(4);
+            expect(result.original).toBe('2024-01-23');
+            expect(result.microseconds).toBe(0);
+        });
+
+        it('returns undefined if no matching timestamp.', () => {
+            // Arrange
+            const text = 'abc';
+
+            // Act
+            const result = testObject.getTimestampFromText(text);
+
+            // Assert
+            expect(result).toBeUndefined();
+        });
     });
 
     describe('getTimePeriod', () => {
+        it('gets the correct timePeriod from two dates of the same format.', () => {
+            // Arrange
+            const firstLine = '2018-01-27 first line';
+            const lastLine = '2020-02-28 last line';
+            const expected = moment.duration({ days: 1, months: 1, years: 2 });
 
-        it('gets the correct timePeriod from "YYYY-MM-DD" and "DD.MM.YYYY".', () => {
+            // Act
+            const result = testObject.getTimePeriod(firstLine, lastLine);
+
+            // Assert
+            expect(result.duration.asMilliseconds()).toBe(expected.asMilliseconds());
+        });
+
+        it('gets the correct timePeriod from two differently formatted dates.', () => {
             // Arrange
             const firstLine = '2018-01-27 first line';
             const lastLine = '28.02.2020 last line';
@@ -55,11 +190,11 @@ describe('TimePeriodCalculator', () => {
             expect(result.duration.asMilliseconds()).toBe(expected.asMilliseconds());
         });
 
-        it('gets the correct timePeriod from "hh:mm:ss.sss" and "hh:mm:ss.sss".', () => {
+        it('gets the correct timePeriod from two times (with milliseconds) with dates.', () => {
             // Arrange
-            const firstLine = '10:38:28.935 first line';
-            const lastLine = '16:51:29,001 last line';
-            const expected = moment.duration({ seconds: 0.066, minutes: 13, hours: 6 });
+            const firstLine = '2018-01-27T10:38:28.935Z first line';
+            const lastLine = '2020-02-28T16:51:29.001Z last line';
+            const expected = moment.duration({ years: 2, months: 1, days: 1, hours: 6, minutes: 13, seconds: 0, milliseconds: 66 });
 
             // Act
             const result = testObject.getTimePeriod(firstLine, lastLine);
@@ -68,7 +203,21 @@ describe('TimePeriodCalculator', () => {
             expect(result.duration.asMilliseconds()).toBe(expected.asMilliseconds());
         });
 
-        it('gets the correct timePeriod from "YYYY-MM-DD hh:mm:ss.ssssss".', () => {
+        it('gets the correct timePeriod from two times (with milliseconds) without dates.', () => {
+            // Arrange
+            const firstLine = '10:38:28.935 first line';
+            const lastLine = '16:51:29,001 last line';
+            const expected = moment.duration({ hours: 6, minutes: 13, seconds: 0, milliseconds: 66 });
+
+            // Act
+            const result = testObject.getTimePeriod(firstLine, lastLine);
+
+            // Assert
+            expect(result.duration.asMilliseconds()).toBe(expected.asMilliseconds());
+            expect(result.durationPartMicroseconds).toBe(0);
+        });
+
+        it('gets the correct timePeriod from with microseconds with dates.', () => {
             // Arrange
             const firstLine = '2023-01-02 10:11:12.100000 first line';
             const lastLine = '2023-01-02 10:11:12.100123 last line';;
@@ -81,7 +230,7 @@ describe('TimePeriodCalculator', () => {
             expect(result.durationPartMicroseconds).toBe(123);
         });
 
-        it('gets the correct timePeriod from "hh:mm:ss.ssssss".', () => {
+        it('gets the correct timePeriod from with microseconds without dates.', () => {
             // Arrange
             const firstLine = '10:11:12.100000 first line';
             const lastLine = '10:11:12.100123 last line';;
@@ -94,63 +243,11 @@ describe('TimePeriodCalculator', () => {
             expect(result.durationPartMicroseconds).toBe(123);
         });
 
-        it('gets the correct timePeriod from "YYYY-MM-DDThh:mm:ss.sssZ" and "DD/MM/YYYThh:mm:ss,sssZ".', () => {
-            // Arrange
-            const firstLine = '2018-01-27T10:38:28.935Z first line';
-            const lastLine = '2020-02-28T16:51:29.001Z last line';
-            const expected = moment.duration({ seconds: 0.066, minutes: 13, hours: 6, days: 1, months: 1, years: 2 });
-
-            // Act
-            const result = testObject.getTimePeriod(firstLine, lastLine);
-
-            // Assert
-            expect(result.duration.asMilliseconds()).toBe(expected.asMilliseconds());
-        });
-
-        it('gets the correct timePeriod from "YYYY-MM-DD hh:mm:ss.sss" and "DD/MM/YYY hh:mm:ss,sss".', () => {
-            // Arrange
-            const firstLine = '2018-01-27 10:38:28.935 first line';
-            const lastLine = '28/02/2020 16:51:29,001 last line';
-            const expected = moment.duration({ seconds: 0.066, minutes: 13, hours: 6, days: 1, months: 1, years: 2 });
-
-            // Act
-            const result = testObject.getTimePeriod(firstLine, lastLine);
-
-            // Assert
-            expect(result.duration.asMilliseconds()).toBe(expected.asMilliseconds());
-        });
-
-        it('gets the correct timePeriod from "YYYY-MM-DD hh:mm" and MM/DD/YYYY hh:mm".', () => {
-            // Arrange
-            const firstLine = '2018-01-27 10:38 first line';
-            const lastLine = '02/28/2020 16:51 last line';;
-            const expected = moment.duration({ minutes: 13, hours: 6, days: 1, months: 1, years: 2 });
-
-            // Act
-            const result = testObject.getTimePeriod(firstLine, lastLine);
-
-            // Assert
-            expect(result.duration.asMilliseconds()).toBe(expected.asMilliseconds());
-        });
-
-        it('should only consider log statements with the same format (length).', () => {
-            // Arrange
-            const firstLine = '2018-01-27 first line';
-            const lastLine = '02/28/2020 last line';
-            const expected = moment.duration({ days: 1, months: 1, years: 2 });
-
-            // Act
-            const result = testObject.getTimePeriod(firstLine, lastLine);
-
-            // Assert
-            expect(result.duration.asMilliseconds()).toBe(expected.asMilliseconds());
-        });
-
         it('should only consider the first timestamp statement of a line.', () => {
             // Arrange
             const firstLine = 'foo bar baz 2018-01-27 first line';
             const lastLine = 'hello world 02/28/2020 last line; 2021-03-29 my fourth statement on same line.';
-            const expected = moment.duration({ days: 1, months: 1, years: 2 });
+            const expected = moment.duration({ years: 2, months: 1, days: 1 });
 
             // Act
             const result = testObject.getTimePeriod(firstLine, lastLine);

--- a/test/unittest/TimePeriodCalculator.test.ts
+++ b/test/unittest/TimePeriodCalculator.test.ts
@@ -259,110 +259,96 @@ describe('TimePeriodCalculator', () => {
 
     describe('convertToDisplayString', () => {
         const PREFIX = 'Selected: ';
+
         it('should only consist of "0μs".', () => {
             // Arrange
-            const input = moment.duration({ seconds: 0 });
-            const expected = PREFIX + input.asMilliseconds() + 'ms';
 
             // Act
             const result = testObject.convertToDisplayString(
                 new TimePeriod(
-                    new TimeWithMicroseconds(moment('2024-02-03 12:13:14'), 0),
-                    new TimeWithMicroseconds(moment('2024-02-03 12:13:14'), 0),
-                    input));
+                    {iso:'2024-02-03 12:13:14', microseconds: 0},
+                    {iso:'2024-02-03 12:13:14', microseconds: 0}));
 
             // Assert
             expect(result).toBe(PREFIX + '0μs');
         });
 
-        it('should only consist of "ms".', () => {
+        it('should only consist of "μs".', () => {
             // Arrange
-            const input = moment.duration({ seconds: 0.123 });
-            const expected = PREFIX + input.asMilliseconds() + 'ms';
 
             // Act
             const result = testObject.convertToDisplayString(
                 new TimePeriod(
-                    new TimeWithMicroseconds(moment('2024-02-03 12:13:14'), 0),
-                    new TimeWithMicroseconds(moment('2024-02-03 12:13:14'), 0),
-                    input));
+                    {iso:'2024-02-03 12:13:14', microseconds: 10},
+                    {iso:'2024-02-03 12:13:14', microseconds: 30}));
 
             // Assert
-            expect(result).toBe(expected);
+            expect(result).toBe(PREFIX + '20μs');
+        });
+
+        it('should only consist of "ms".', () => {
+            // Arrange
+
+            // Act
+            const result = testObject.convertToDisplayString(
+                new TimePeriod(
+                    {iso:'2024-02-03 12:13:14.000', microseconds: 0},
+                    {iso:'2024-02-03 12:13:14.123', microseconds: 0}));
+
+            // Assert
+            expect(result).toBe(PREFIX + '123ms');
         });
 
         it('should only consist of "s" and "ms".', () => {
             // Arrange
-            const input = moment.duration({ seconds: 6.123 });
-            const expected = PREFIX + input.seconds() + 's, '
-                + input.milliseconds() + 'ms';
 
             // Act
             const result = testObject.convertToDisplayString(
                 new TimePeriod(
-                    new TimeWithMicroseconds(moment('2024-02-03 12:13:14'), 0),
-                    new TimeWithMicroseconds(moment('2024-02-03 12:13:14'), 0),
-                    input));
+                    {iso:'2024-02-03 12:13:14.000', microseconds: 0},
+                    {iso:'2024-02-03 12:13:20.123', microseconds: 0}));
 
             // Assert
-            expect(result).toBe(expected);
+            expect(result).toBe(PREFIX + '6s, 123ms');
         });
 
         it('should only consist of "min", "s" and "ms".', () => {
             // Arrange
-            const input = moment.duration({ seconds: 6.123, minutes: 3 });
-            const expected = PREFIX + input.minutes() + 'min, '
-                + input.seconds() + 's, '
-                + input.milliseconds() + 'ms';
 
             // Act
             const result = testObject.convertToDisplayString(
                 new TimePeriod(
-                    new TimeWithMicroseconds(moment('2024-02-03 12:13:14'), 0),
-                    new TimeWithMicroseconds(moment('2024-02-03 12:13:14'), 0),
-                    input));
+                    {iso:'2024-02-03 12:13:14.000', microseconds: 0},
+                    {iso:'2024-02-03 12:16:20.123', microseconds: 0},));
 
             // Assert
-            expect(result).toBe(expected);
+            expect(result).toBe(PREFIX + '3min, 6s, 123ms');
         });
 
         it('should only consist of "h", "min", "s" and "ms".', () => {
             // Arrange
-            const input = moment.duration({ seconds: 6.123, minutes: 0, hours: 5 });
-            const expected = PREFIX + input.hours() + 'h, '
-                + input.minutes() + 'min, '
-                + input.seconds() + 's, '
-                + input.milliseconds() + 'ms';
 
             // Act
             const result = testObject.convertToDisplayString(
                 new TimePeriod(
-                    new TimeWithMicroseconds(moment('2024-02-03 12:13:14'), 0),
-                    new TimeWithMicroseconds(moment('2024-02-03 12:13:14'), 0),
-                    input));
+                    {iso:'2024-02-03 12:13:14.000', microseconds: 0},
+                    {iso:'2024-02-03 17:13:20.123', microseconds: 0}));
 
             // Assert
-            expect(result).toBe(expected);
+            expect(result).toBe(PREFIX + '5h, 0min, 6s, 123ms');
         });
 
         it('should consist of "d", "h", "min", "s" and "ms".', () => {
             // Arrange
-            const input = moment.duration({ seconds: 6.123, minutes: 0, hours: 5, days: 15, years: 2 });
-            const expected = PREFIX + Math.floor(input.asDays()) + 'd, '
-                + input.hours() + 'h, '
-                + input.minutes() + 'min, '
-                + input.seconds() + 's, '
-                + input.milliseconds() + 'ms';
 
             // Act
             const result = testObject.convertToDisplayString(
                 new TimePeriod(
-                    new TimeWithMicroseconds(moment('2024-02-03 12:13:14'), 0),
-                    new TimeWithMicroseconds(moment('2024-02-03 12:13:14'), 0),
-                    input));
+                    {iso:'2022-02-03 12:13:14', microseconds: 0},
+                    {iso:'2024-02-18 17:13:20', microseconds: 0}));
 
             // Assert
-            expect(result).toBe(expected);
+            expect(result).toBe(PREFIX + '745d, 5h, 0min, 6s, 0ms');
         });
     });
 });

--- a/test/unittest/TimePeriodCalculator.test.ts
+++ b/test/unittest/TimePeriodCalculator.test.ts
@@ -2,7 +2,7 @@
 
 import * as moment from 'moment';
 import { TimePeriodCalculator } from '../../src/TimePeriodCalculator';
-import { TimePeriod, TimeWithMicroseconds } from '../../src/TimePeriod';
+import { TimePeriod } from '../../src/TimePeriod';
 
 describe('TimePeriodCalculator', () => {
     let testObject: TimePeriodCalculator;
@@ -266,8 +266,8 @@ describe('TimePeriodCalculator', () => {
             // Act
             const result = testObject.convertToDisplayString(
                 new TimePeriod(
-                    {iso:'2024-02-03 12:13:14', microseconds: 0},
-                    {iso:'2024-02-03 12:13:14', microseconds: 0}));
+                    { iso: '2024-02-03 12:13:14', microseconds: 0 },
+                    { iso: '2024-02-03 12:13:14', microseconds: 0 }));
 
             // Assert
             expect(result).toBe(PREFIX + '0μs');
@@ -279,8 +279,8 @@ describe('TimePeriodCalculator', () => {
             // Act
             const result = testObject.convertToDisplayString(
                 new TimePeriod(
-                    {iso:'2024-02-03 12:13:14', microseconds: 10},
-                    {iso:'2024-02-03 12:13:14', microseconds: 30}));
+                    { iso: '2024-02-03 12:13:14', microseconds: 10 },
+                    { iso: '2024-02-03 12:13:14', microseconds: 30 }));
 
             // Assert
             expect(result).toBe(PREFIX + '20μs');
@@ -292,8 +292,8 @@ describe('TimePeriodCalculator', () => {
             // Act
             const result = testObject.convertToDisplayString(
                 new TimePeriod(
-                    {iso:'2024-02-03 12:13:14.000', microseconds: 0},
-                    {iso:'2024-02-03 12:13:14.123', microseconds: 0}));
+                    { iso: '2024-02-03 12:13:14.000', microseconds: 0 },
+                    { iso: '2024-02-03 12:13:14.123', microseconds: 0 }));
 
             // Assert
             expect(result).toBe(PREFIX + '123ms');
@@ -305,8 +305,8 @@ describe('TimePeriodCalculator', () => {
             // Act
             const result = testObject.convertToDisplayString(
                 new TimePeriod(
-                    {iso:'2024-02-03 12:13:14.000', microseconds: 0},
-                    {iso:'2024-02-03 12:13:20.123', microseconds: 0}));
+                    { iso: '2024-02-03 12:13:14.000', microseconds: 0 },
+                    { iso: '2024-02-03 12:13:20.123', microseconds: 0 }));
 
             // Assert
             expect(result).toBe(PREFIX + '6s, 123ms');
@@ -318,8 +318,8 @@ describe('TimePeriodCalculator', () => {
             // Act
             const result = testObject.convertToDisplayString(
                 new TimePeriod(
-                    {iso:'2024-02-03 12:13:14.000', microseconds: 0},
-                    {iso:'2024-02-03 12:16:20.123', microseconds: 0},));
+                    { iso: '2024-02-03 12:13:14.000', microseconds: 0 },
+                    { iso: '2024-02-03 12:16:20.123', microseconds: 0 },));
 
             // Assert
             expect(result).toBe(PREFIX + '3min, 6s, 123ms');
@@ -331,8 +331,8 @@ describe('TimePeriodCalculator', () => {
             // Act
             const result = testObject.convertToDisplayString(
                 new TimePeriod(
-                    {iso:'2024-02-03 12:13:14.000', microseconds: 0},
-                    {iso:'2024-02-03 17:13:20.123', microseconds: 0}));
+                    { iso: '2024-02-03 12:13:14.000', microseconds: 0 },
+                    { iso: '2024-02-03 17:13:20.123', microseconds: 0 }));
 
             // Assert
             expect(result).toBe(PREFIX + '5h, 0min, 6s, 123ms');
@@ -344,8 +344,8 @@ describe('TimePeriodCalculator', () => {
             // Act
             const result = testObject.convertToDisplayString(
                 new TimePeriod(
-                    {iso:'2022-02-03 12:13:14', microseconds: 0},
-                    {iso:'2024-02-18 17:13:20', microseconds: 0}));
+                    { iso: '2022-02-03 12:13:14', microseconds: 0 },
+                    { iso: '2024-02-18 17:13:20', microseconds: 0 }));
 
             // Assert
             expect(result).toBe(PREFIX + '745d, 5h, 0min, 6s, 0ms');

--- a/test/unittest/TimePeriodCalculator.test.ts
+++ b/test/unittest/TimePeriodCalculator.test.ts
@@ -2,6 +2,7 @@
 
 import * as moment from 'moment';
 import { TimePeriodCalculator } from '../../src/TimePeriodCalculator';
+import { TimePeriod } from '../../src/TimePeriod';
 
 describe('TimePeriodCalculator', () => {
     let testObject: TimePeriodCalculator;
@@ -111,7 +112,7 @@ describe('TimePeriodCalculator', () => {
             const expected = PREFIX + input.asMilliseconds() + 'ms';
 
             // Act
-            const result = testObject.convertToDisplayString(input);
+            const result = testObject.convertToDisplayString(new TimePeriod(undefined, undefined, input));
 
             // Assert
             expect(result).toBe(expected);
@@ -123,7 +124,7 @@ describe('TimePeriodCalculator', () => {
             const expected = PREFIX + input.asMilliseconds() + 'ms';
 
             // Act
-            const result = testObject.convertToDisplayString(input);
+            const result = testObject.convertToDisplayString(new TimePeriod(undefined, undefined, input));
 
             // Assert
             expect(result).toBe(expected);
@@ -136,7 +137,7 @@ describe('TimePeriodCalculator', () => {
                 + input.milliseconds() + 'ms';
 
             // Act
-            const result = testObject.convertToDisplayString(input);
+            const result = testObject.convertToDisplayString(new TimePeriod(undefined, undefined, input));
 
             // Assert
             expect(result).toBe(expected);
@@ -150,7 +151,7 @@ describe('TimePeriodCalculator', () => {
                 + input.milliseconds() + 'ms';
 
             // Act
-            const result = testObject.convertToDisplayString(input);
+            const result = testObject.convertToDisplayString(new TimePeriod(undefined, undefined, input));
 
             // Assert
             expect(result).toBe(expected);
@@ -165,7 +166,7 @@ describe('TimePeriodCalculator', () => {
                 + input.milliseconds() + 'ms';
 
             // Act
-            const result = testObject.convertToDisplayString(input);
+            const result = testObject.convertToDisplayString(new TimePeriod(undefined, undefined, input));
 
             // Assert
             expect(result).toBe(expected);
@@ -181,7 +182,7 @@ describe('TimePeriodCalculator', () => {
                 + input.milliseconds() + 'ms';
 
             // Act
-            const result = testObject.convertToDisplayString(input);
+            const result = testObject.convertToDisplayString(new TimePeriod(undefined, undefined, input));
 
             // Assert
             expect(result).toBe(expected);


### PR DESCRIPTION
Added support for microsecond precision for timestamps in time period duration calculations and timestamp progress indicators.

Example timestamp: 2023-09-26 18:24:17.035169

Before this change, only millisecond precision was supported, so the last three digits in the timestamp above was lost. This was caused by limited time precision support in Javascript and the new microsecond precision has required explicit handling in the extension to keep track of the number of microseconds.

Also did some refactoring and rewriting of unit tests.

Fixes #65 and #594.