### PR TITLE
extend trace regex to accept TRACE

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The extension associates with `.log` files and applies coloring to the different
 | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
 | Dates and times in ISO format, such as           | `2015-12-09`, `2015-12-09 09:29`, `2015-12-09 09:29:02.258`                                                              |
 | Dates and times in some culture-specific formats | `12/09/2016`, `12.09.2016`, `12-09-2016`, `12-09-2015 09:29`, `12-09-2015 09:29:02,258`                                 |
-| Log level                                        | `DEBUG`, `INFO`, `INFORMATION`, `WARN`, `WARNING`, `ERROR`, `FAIL`, `FAILURE`                                            |
+| Log level                                        | `TRACE`, `DEBUG`, `INFO`, `INFORMATION`, `WARN`, `WARNING`, `ERROR`, `FAIL`, `FAILURE`                                            |
 | Numeric constants                                | `1`, `234`                                                                                                               |
 | Standard .Net constants                          | `null`, `true`, `false`                                                                                                  |
 | String constants                                 | `"lorem ipsum"`, `'lorem ipsum'`                                                                                         |

--- a/syntaxes/log.tmLanguage
+++ b/syntaxes/log.tmLanguage
@@ -21,7 +21,7 @@
 			<!-- Trace/Verbose -->
 			<dict>
 				<key>match</key>
-				<string>\b(Trace)\b:</string>
+				<string>\b([Tt]race|TRACE)\b:?</string>
 
 				<key>name</key>
 				<string>comment log.verbose</string>


### PR DESCRIPTION
* extend `trace`  rule to accept "TRACE" and also without a colon, which is used by Rust loggers for example